### PR TITLE
Fix: Use I_OR_E to select TRAP_ADDRESS

### DIFF
--- a/steel_core.v
+++ b/steel_core.v
@@ -1093,7 +1093,7 @@ module csr_file(
     wire [31:0] base_offset;
     wire [31:0] mtvec_reset_value = `MTVEC_RESET;
     assign base_offset = CAUSE_IN << 2;
-    assign trap_mux_out = int_or_exc ? vec_mux_out : {mtvec_base, 2'b00};
+    assign trap_mux_out = I_OR_E ? vec_mux_out : {mtvec_base, 2'b00};
     assign vec_mux_out = mtvec[0] ? {mtvec_base, 2'b00} + base_offset : {mtvec_base, 2'b00};
     assign TRAP_ADDRESS = trap_mux_out;
     always @(posedge CLK)


### PR DESCRIPTION
When an exception occurred, TRAP handled the previous value of bit 31 (Interrupt) in the mcause register (aka int_or_exc).
This change uses I_OR_E in place of int_or_exc to select TRAP_ADDRESS